### PR TITLE
Adding latest drift code

### DIFF
--- a/chat-annoyances.txt
+++ b/chat-annoyances.txt
@@ -26,5 +26,6 @@ widgets.getsitecontrol.com*script.js
 ||zendesk.com*host.js
 *GetOnlineChatUrl*
 js.driftt.com/dist/assets/widget*prod.js
+js.driftt.com/include/*
 call.chatra.io/chatra.js
 ||mylivechat.com/chatinline.aspx


### PR DESCRIPTION
I noticed drift was still appearing & it looks like they updated their embed code URL a little to block URLs like `https://js.driftt.com/include/1552216500000/5y6gff9fu2nz.js`.

You can see the current rules getting through on https://documentation.codeship.com/basic/continuous-deployment/deployment-to-aws-codedeploy/ 